### PR TITLE
Add nodots backgammon core integration helpers

### DIFF
--- a/doc/nodots-integration-plan.md
+++ b/doc/nodots-integration-plan.md
@@ -1,0 +1,69 @@
+# Plan: Integrating `gnubg-hints` with the nodots-backgammon Ecosystem
+
+## 1. Objectives and Success Criteria
+- Provide nodots applications with GNU Backgammon-quality move, double, and take hints via the existing native addon API without blocking gameplay flows.
+- Maintain type compatibility with the `@nodots-llc/backgammon-types` models consumed by `@nodots-llc/backgammon-core` while keeping GNU Backgammon logic isolated from the core game rules implementation.
+- Deliver a production-ready package (or service) that can be deployed alongside other nodots services with automated testing, monitoring, and documentation.
+
+Success will be measured by:
+- End-to-end hint retrieval inside a nodots application using a real `BackgammonBoard` from the core library.
+- Integration tests that exercise move hint, double, and take APIs across representative match states.
+- Automated build artifacts (npm package or container image) published to the nodots package registry and deployable in staging.
+
+## 2. Current State Assessment
+1. **GNU Backgammon hint engine** – The `gnubg-node-addon` already wraps GNU Backgammon's evaluation logic in a Node.js native addon with async APIs for move, double, and take hints, using TypeScript types from `@nodots-llc/backgammon-types`.【F:gnubg-node-addon/README.md†L1-L93】
+2. **nodots backgammon core** – The `@nodots-llc/backgammon-core` package provides gameplay state, move validation, and player turn management for nodots products, exporting board representations compatible with the hint addon.【e17a0a†L8-L89】
+3. **Gaps** – There is no documented workflow to pull game state from `backgammon-core`, send it to the hint addon, and surface results to clients. Build/release automation for combining the repositories is also undefined.
+
+## 3. Integration Strategy Overview
+We propose a four-phase plan that separates discovery, infrastructure, product integration, and rollout.
+
+### Phase A – Alignment & Architecture (1–2 sprints)
+1. **Repository strategy** – Keep `gnubg-hints` as a standalone, GPL-licensed npm package that nodots applications consume as a dependency. Maintain the native addon source in this repository while incrementally porting surfaces to TypeScript definitions. Define a release pipeline (e.g., GitHub Actions) that builds multi-platform binaries, runs tests, and publishes tagged releases to the nodots npm scope (and mirrored public registry if required) with automated changelog generation.
+2. **API compatibility matrix** – Verify that `BackgammonBoard` and related DTOs emitted by `backgammon-core` map cleanly to the hint requests defined by the addon. Capture any normalization/conversion requirements (e.g., checker ordering, cube owner enums) in documentation and unit tests.
+3. **Resource management plan** – Benchmark addon initialization, concurrent request handling, and shutdown semantics so they can be embedded in stateless services or long-running Node.js workers. Define caching strategy for neural-network weights, thread pool sizing, and per-request timeouts.
+4. **Security & licensing review** – Confirm GPL obligations when embedding GNU Backgammon in nodots offerings, and establish OSS attribution documentation and distribution requirements.
+
+### Phase B – Infrastructure & Packaging (2–3 sprints)
+1. **Build automation** – Create CI jobs that compile the native addon for Linux, macOS, and Windows targets with the Node.js versions supported by nodots. Publish artifacts to a private npm registry or attach to releases.
+2. **Containerization** – If nodots uses container deployments, build a minimal image that bundles the addon, neural network weights, and any required runtime dependencies. Validate startup time and memory usage.
+3. **Configuration management** – Externalize evaluation parameters (plies, move filters, pruning) and weight paths so they can be tuned per environment without code changes.【F:gnubg-node-addon/README.md†L21-L76】
+4. **Observability hooks** – Standardize logging, metrics, and tracing around the addon using nodots conventions (e.g., `[Core]` logger structure). Ensure hint requests/responses can be correlated with gameplay events from `backgammon-core` logs.【e17a0a†L91-L168】
+
+### Phase C – Application Integration (2–4 sprints)
+1. **Core-library bridge** – Implement a TypeScript bridge module inside the nodots ecosystem that takes a `Play` or `Game` state from `backgammon-core`, derives the required hint request payload, and invokes the addon asynchronously. Include fallback logic when hints are unavailable.
+2. **Feature flag rollout** – Wrap hint consumption in a configurable feature flag to allow gradual enablement across products. Support toggling move hints, cube actions, and take decisions independently.
+3. **Client experience** – Update any UI/API layers (web, mobile, or backend services) to consume the new hints. Provide presentation models with rank, equity, cube decisions, and differences as surfaced by the addon.【F:gnubg-node-addon/README.md†L47-L92】
+4. **Error handling** – Define retry/backoff strategies and user messaging when evaluations fail or time out. Capture diagnostics for debugging (input board state, dice, cube status) while respecting privacy/security policies.
+
+### Phase D – Verification & Rollout (2 sprints)
+1. **Testing strategy**
+   - Unit tests for the bridge module converting between core game state and addon requests.
+   - Integration tests simulating match scenarios that call the addon and verify hint ordering, cube decisions, and take/drop advice.
+   - Performance tests measuring throughput under simultaneous hint requests.
+2. **Staging validation** – Deploy to a staging environment, run shadow sessions comparing addon recommendations with baseline heuristics, and gather stakeholder sign-off.
+3. **Operational readiness** – Finalize runbooks, SLOs, alerting thresholds, and on-call playbooks. Document upgrade procedures for neural-network weights and addon versions.
+4. **Launch & feedback loop** – Roll out behind flags, monitor telemetry, collect player feedback, and schedule follow-up improvements (e.g., batch processing, offline caching).
+
+## 4. Dependencies & Open Questions
+- Confirm licensing/distribution obligations for combining GPL code with nodots commercial offerings.
+- Determine long-term ownership for maintaining the native addon and GNU Backgammon updates.
+- Decide whether hint evaluation should run server-side, client-side, or both (impacts build targets and packaging).
+- Evaluate hardware requirements (CPU vs. GPU) for target platforms and potential need for horizontal scaling.
+
+## 5. Deliverables Checklist
+- ✅ Architectural decision record covering deployment model and licensing stance.
+- ✅ CI/CD pipelines producing tested artifacts for all supported environments.
+- ✅ Documentation for developers (setup, usage examples, troubleshooting) and operators (metrics, alerts, runbooks).
+- ✅ Automated test suite integrated into nodots pipelines with coverage thresholds.
+- ✅ Feature-flagged release across nodots applications with monitoring dashboards tracking hint usage and performance.
+
+## 6. Timeline Snapshot (adjustable)
+| Phase | Duration | Key Milestones |
+| --- | --- | --- |
+| A | 1–2 sprints | Compatibility matrix, architecture decision record |
+| B | 2–3 sprints | Multi-platform builds, container image, config/observability |
+| C | 2–4 sprints | Bridge module, client updates, feature flags |
+| D | 2 sprints | Staging sign-off, operational readiness, production rollout |
+
+Total estimate: 7–11 sprints depending on team capacity and licensing outcomes.

--- a/gnubg-node-addon/README.md
+++ b/gnubg-node-addon/README.md
@@ -68,6 +68,31 @@ console.log(`Action: ${doubleHint.action}`); // "double", "no-double", "too-good
 GnuBgHints.shutdown();
 ```
 
+### Creating hint requests from `@nodots-llc/backgammon-core`
+
+When working with game objects produced by `@nodots-llc/backgammon-core`, the
+package exposes a helper that converts the game state (board, cube, match
+metadata, and dice) into the `HintRequest` structure expected by the native
+addon:
+
+```typescript
+import { createHintRequestFromGame, GnuBgHints } from '@nodots/gnubg-hints';
+import type { BackgammonGame } from '@nodots-llc/backgammon-types';
+
+async function getBestMove(game: BackgammonGame) {
+  await GnuBgHints.initialize();
+
+  const hintRequest = createHintRequestFromGame(game, {
+    // Provide defaults for optional values not tracked by the core engine
+    defaultDice: [0, 0],
+    jacoby: true,
+    beavers: true
+  });
+
+  return GnuBgHints.getMoveHints(hintRequest, 5);
+}
+```
+
 ### Command line interface
 
 After building the project you can use the bundled CLI to retrieve the top five moves for a GNU position ID and dice roll:

--- a/gnubg-node-addon/src/index.ts
+++ b/gnubg-node-addon/src/index.ts
@@ -2,35 +2,30 @@ import {
   BackgammonBoard,
   BackgammonColor
 } from '@nodots-llc/backgammon-types';
+import type {
+  CheckerLike,
+  DoubleHint,
+  Evaluation,
+  HintBoard,
+  HintConfig,
+  HintRequest,
+  MoveHint,
+  MoveStep,
+  SimplifiedCheckerContainer,
+  TakeHint
+} from './types';
 
-type CheckerLike = {
-  color?: BackgammonColor;
-  id?: string;
-};
-
-interface SimplifiedCheckerContainer {
-  id?: string;
-  position?: {
-    clockwise?: number;
-    counterclockwise?: number;
-  };
-  checkers?: CheckerLike[];
-}
-
-interface SimplifiedBoard {
-  id?: string;
-  points: SimplifiedCheckerContainer[];
-  bar: {
-    clockwise?: { checkers?: CheckerLike[] };
-    counterclockwise?: { checkers?: CheckerLike[] };
-  };
-  off: {
-    clockwise?: { checkers?: CheckerLike[] };
-    counterclockwise?: { checkers?: CheckerLike[] };
-  };
-}
-
-export type HintBoard = BackgammonBoard | SimplifiedBoard;
+export type {
+  CheckerLike,
+  DoubleHint,
+  Evaluation,
+  HintBoard,
+  HintConfig,
+  HintRequest,
+  MoveHint,
+  MoveStep,
+  TakeHint
+} from './types';
 
 // Native addon binding
 const addon = require('../build/Release/gnubg_hints.node');
@@ -38,84 +33,6 @@ const addon = require('../build/Release/gnubg_hints.node');
 /**
  * Request structure for hint evaluation
  */
-export interface HintRequest {
-  board: HintBoard;
-  dice: [number, number];
-  cubeValue: number;
-  cubeOwner: BackgammonColor | null;
-  matchScore: [number, number];
-  matchLength: number;
-  crawford: boolean;
-  jacoby: boolean;
-  beavers: boolean;
-}
-
-/**
- * Evaluation output from GNU Backgammon neural network
- */
-export interface Evaluation {
-  win: number;           // Probability of winning
-  winGammon: number;     // Probability of winning a gammon
-  winBackgammon: number; // Probability of winning a backgammon
-  loseGammon: number;    // Probability of losing a gammon
-  loseBackgammon: number;// Probability of losing a backgammon
-  equity: number;        // Position equity
-  cubefulEquity?: number;// Cubeful equity (if applicable)
-}
-
-/**
- * Move hint with evaluation
- */
-export interface MoveHint {
-  moves: MoveStep[];
-  evaluation: Evaluation;
-  equity: number;
-  rank: number;
-  difference: number; // Equity difference from best move
-}
-
-export interface MoveStep {
-  from: number;
-  to: number;
-  moveKind: 'point-to-point' | 'reenter' | 'bear-off';
-  isHit: boolean;
-  player: BackgammonColor;
-  fromContainer: 'bar' | 'point' | 'off';
-  toContainer: 'bar' | 'point' | 'off';
-}
-
-/**
- * Doubling cube decision hint
- */
-export interface DoubleHint {
-  action: 'double' | 'no-double' | 'too-good' | 'beaver' | 'redouble';
-  takePoint: number;
-  dropPoint: number;
-  evaluation: Evaluation;
-  cubefulEquity: number;
-}
-
-/**
- * Take/Drop decision hint
- */
-export interface TakeHint {
-  action: 'take' | 'drop' | 'beaver';
-  evaluation: Evaluation;
-  takeEquity: number;
-  dropEquity: number;
-}
-
-/**
- * Configuration for the hint engine
- */
-export interface HintConfig {
-  evalPlies?: number;      // Evaluation depth (0-3)
-  moveFilter?: number;     // Move filter level (0-4)
-  threadCount?: number;    // Number of threads for evaluation
-  usePruning?: boolean;    // Use pruning neural networks
-  noise?: number;          // Evaluation noise (0.0 = deterministic)
-}
-
 /**
  * GNU Backgammon hint engine
  */
@@ -596,6 +513,17 @@ export class GnuBgHints {
     };
   }
 }
+
+export type { GameHintContextOverrides } from './integration/backgammon-core';
+
+export {
+  createHintRequestFromGame,
+  deriveCubeOwner,
+  deriveCubeValue,
+  deriveDiceFromGame,
+  deriveMatchLength,
+  deriveMatchScore
+} from './integration/backgammon-core';
 
 // Export default instance
 export default GnuBgHints;

--- a/gnubg-node-addon/src/integration/backgammon-core.ts
+++ b/gnubg-node-addon/src/integration/backgammon-core.ts
@@ -1,0 +1,167 @@
+import type {
+  BackgammonBoard,
+  BackgammonColor,
+  BackgammonCube,
+  BackgammonCubeValue,
+  BackgammonDice,
+  BackgammonDiceRolled,
+  BackgammonGame,
+  BackgammonPlayer,
+  MatchInfo
+} from '@nodots-llc/backgammon-types';
+import type { HintRequest } from '../types';
+
+export interface GameHintContextOverrides
+  extends Partial<Omit<HintRequest, 'board' | 'dice'>> {
+  /**
+   * Override the board that should be evaluated. Defaults to `game.board`.
+   */
+  board?: BackgammonBoard;
+  /**
+   * Override dice used for move generation. When omitted the helper will
+   * attempt to derive the current roll from the active player or play state.
+   */
+  dice?: [number, number];
+  /**
+   * Dice to fall back to when no active roll can be discovered.
+   * Defaults to `[0, 0]` which is appropriate for cube decisions
+   * or situations where dice have not been rolled yet.
+   */
+  defaultDice?: [number, number];
+  /**
+   * Optional match metadata when it is not embedded in the game object.
+   */
+  matchInfo?: MatchInfo;
+}
+
+const DEFAULT_DICE: [number, number] = [0, 0];
+
+/**
+ * Create a {@link HintRequest} from a {@link BackgammonGame} instance exported by
+ * `@nodots-llc/backgammon-core`.
+ */
+export function createHintRequestFromGame(
+  game: BackgammonGame,
+  overrides: GameHintContextOverrides = {}
+): HintRequest {
+  const board: BackgammonBoard | undefined = overrides.board ?? game.board;
+  if (!board) {
+    throw new Error('Backgammon game is missing a board state.');
+  }
+
+  const dice = overrides.dice ?? deriveDiceFromGame(game) ?? overrides.defaultDice ?? DEFAULT_DICE;
+
+  const matchInfo = overrides.matchInfo ?? extractMatchInfo(game);
+
+  return {
+    board,
+    dice,
+    cubeValue: overrides.cubeValue ?? deriveCubeValue(game.cube),
+    cubeOwner: overrides.cubeOwner ?? deriveCubeOwner(game.cube),
+    matchScore: overrides.matchScore ?? deriveMatchScore(matchInfo),
+    matchLength: overrides.matchLength ?? deriveMatchLength(matchInfo),
+    crawford: overrides.crawford ?? deriveCrawford(matchInfo),
+    jacoby: overrides.jacoby ?? Boolean(game.rules?.useJacobyRule),
+    beavers: overrides.beavers ?? Boolean(game.rules?.useBeaverRule)
+  };
+}
+
+/**
+ * Attempt to determine the currently rolled dice from a game state.
+ * Returns `undefined` when the active player has not rolled yet.
+ */
+export function deriveDiceFromGame(game: BackgammonGame): [number, number] | undefined {
+  const fromActivePlayer = getDiceFromPlayer(game.activePlayer);
+  if (fromActivePlayer) {
+    return fromActivePlayer;
+  }
+
+  const fromActivePlay = getDiceFromActivePlay(game);
+  if (fromActivePlay) {
+    return fromActivePlay;
+  }
+
+  const fromInactivePlayer = getDiceFromPlayer(game.inactivePlayer);
+  return fromInactivePlayer;
+}
+
+function getDiceFromActivePlay(game: BackgammonGame): [number, number] | undefined {
+  const play: BackgammonGame['activePlay'] = game.activePlay;
+  if (!play) {
+    return undefined;
+  }
+
+  if ((play as { stateKind: string }).stateKind === 'doubled') {
+    const doubledPlay = play as unknown as { dice: BackgammonDiceRolled | undefined };
+    if (doubledPlay.dice && isDiceRolled(doubledPlay.dice)) {
+      return cloneRoll(doubledPlay.dice.currentRoll);
+    }
+  }
+
+  return undefined;
+}
+
+function getDiceFromPlayer(player: BackgammonPlayer | undefined): [number, number] | undefined {
+  if (!player) {
+    return undefined;
+  }
+
+  const dice: BackgammonDice | undefined = (player as { dice?: BackgammonDice }).dice;
+  if (dice && isDiceRolled(dice)) {
+    return cloneRoll(dice.currentRoll);
+  }
+
+  return undefined;
+}
+
+function isDiceRolled(dice: BackgammonDice): dice is BackgammonDiceRolled {
+  return dice.stateKind === 'rolled' && Array.isArray(dice.currentRoll);
+}
+
+function cloneRoll(roll: BackgammonDiceRolled['currentRoll']): [number, number] {
+  const [first, second] = roll;
+  return [first, second];
+}
+
+function deriveCubeValue(cube: BackgammonCube | undefined): number {
+  const value: BackgammonCubeValue | undefined = cube?.value;
+  return typeof value === 'number' ? value : 1;
+}
+
+function deriveCubeOwner(cube: BackgammonCube | undefined): BackgammonColor | null {
+  return cube?.owner?.color ?? null;
+}
+
+function deriveMatchScore(matchInfo: MatchInfo | undefined): [number, number] {
+  if (!matchInfo?.matchScore) {
+    return [0, 0];
+  }
+
+  const whiteScore = matchInfo.matchScore.white ?? 0;
+  const blackScore = matchInfo.matchScore.black ?? 0;
+  return [whiteScore, blackScore];
+}
+
+function deriveMatchLength(matchInfo: MatchInfo | undefined): number {
+  return matchInfo?.matchLength ?? 0;
+}
+
+function deriveCrawford(matchInfo: MatchInfo | undefined): boolean {
+  if (typeof matchInfo?.isCrawford === 'boolean') {
+    return matchInfo.isCrawford;
+  }
+
+  return false;
+}
+
+function extractMatchInfo(game: BackgammonGame): MatchInfo | undefined {
+  const metadata = game.metadata as { matchInfo?: MatchInfo } | undefined;
+  return metadata?.matchInfo;
+}
+
+export {
+  deriveCubeOwner,
+  deriveCubeValue,
+  deriveMatchLength,
+  deriveMatchScore
+};

--- a/gnubg-node-addon/src/types.ts
+++ b/gnubg-node-addon/src/types.ts
@@ -1,0 +1,111 @@
+import type { BackgammonBoard, BackgammonColor } from '@nodots-llc/backgammon-types';
+
+export type CheckerLike = {
+  color?: BackgammonColor;
+  id?: string;
+};
+
+export interface SimplifiedCheckerContainer {
+  id?: string;
+  position?: {
+    clockwise?: number;
+    counterclockwise?: number;
+  };
+  checkers?: CheckerLike[];
+}
+
+export interface SimplifiedBoard {
+  id?: string;
+  points: SimplifiedCheckerContainer[];
+  bar: {
+    clockwise?: { checkers?: CheckerLike[] };
+    counterclockwise?: { checkers?: CheckerLike[] };
+  };
+  off: {
+    clockwise?: { checkers?: CheckerLike[] };
+    counterclockwise?: { checkers?: CheckerLike[] };
+  };
+}
+
+export type HintBoard = BackgammonBoard | SimplifiedBoard;
+
+/**
+ * Request structure for hint evaluation
+ */
+export interface HintRequest {
+  board: HintBoard;
+  dice: [number, number];
+  cubeValue: number;
+  cubeOwner: BackgammonColor | null;
+  matchScore: [number, number];
+  matchLength: number;
+  crawford: boolean;
+  jacoby: boolean;
+  beavers: boolean;
+}
+
+/**
+ * Evaluation output from GNU Backgammon neural network
+ */
+export interface Evaluation {
+  win: number; // Probability of winning
+  winGammon: number; // Probability of winning a gammon
+  winBackgammon: number; // Probability of winning a backgammon
+  loseGammon: number; // Probability of losing a gammon
+  loseBackgammon: number; // Probability of losing a backgammon
+  equity: number; // Position equity
+  cubefulEquity?: number; // Cubeful equity (if applicable)
+}
+
+/**
+ * Move hint with evaluation
+ */
+export interface MoveHint {
+  moves: MoveStep[];
+  evaluation: Evaluation;
+  equity: number;
+  rank: number;
+  difference: number; // Equity difference from best move
+}
+
+export interface MoveStep {
+  from: number;
+  to: number;
+  moveKind: 'point-to-point' | 'reenter' | 'bear-off';
+  isHit: boolean;
+  player: BackgammonColor;
+  fromContainer: 'bar' | 'point' | 'off';
+  toContainer: 'bar' | 'point' | 'off';
+}
+
+/**
+ * Doubling cube decision hint
+ */
+export interface DoubleHint {
+  action: 'double' | 'no-double' | 'too-good' | 'beaver' | 'redouble';
+  takePoint: number;
+  dropPoint: number;
+  evaluation: Evaluation;
+  cubefulEquity: number;
+}
+
+/**
+ * Take/Drop decision hint
+ */
+export interface TakeHint {
+  action: 'take' | 'drop' | 'beaver';
+  evaluation: Evaluation;
+  takeEquity: number;
+  dropEquity: number;
+}
+
+/**
+ * Configuration for the hint engine
+ */
+export interface HintConfig {
+  evalPlies?: number; // Evaluation depth (0-3)
+  moveFilter?: number; // Move filter level (0-4)
+  threadCount?: number; // Number of threads for evaluation
+  usePruning?: boolean; // Use pruning neural networks
+  noise?: number; // Evaluation noise (0.0 = deterministic)
+}

--- a/gnubg-node-addon/test/backgammon-core-bridge.test.ts
+++ b/gnubg-node-addon/test/backgammon-core-bridge.test.ts
@@ -1,0 +1,225 @@
+import {
+  createHintRequestFromGame,
+  deriveDiceFromGame
+} from '../src';
+import type {
+  BackgammonBoard,
+  BackgammonCube,
+  BackgammonDiceRolled,
+  BackgammonGame,
+  BackgammonPlayer,
+  BackgammonPlayerInactive,
+  BackgammonPlayerMoving,
+  MatchInfo
+} from '@nodots-llc/backgammon-types';
+
+describe('Backgammon core bridge helpers', () => {
+  it('creates a hint request using data from the game state', () => {
+    const game = createStubGame();
+
+    const request = createHintRequestFromGame(game);
+
+    expect(request.board).toBe(game.board);
+    expect(request.dice).toEqual<[number, number]>([3, 1]);
+    expect(request.cubeValue).toBe(4);
+    expect(request.cubeOwner).toBe('white');
+    expect(request.matchScore).toEqual<[number, number]>([2, 4]);
+    expect(request.matchLength).toBe(7);
+    expect(request.crawford).toBe(true);
+    expect(request.jacoby).toBe(true);
+    expect(request.beavers).toBe(false);
+  });
+
+  it('allows overriding derived properties', () => {
+    const game = createStubGame();
+
+    const request = createHintRequestFromGame(game, {
+      dice: [6, 6],
+      cubeValue: 8,
+      cubeOwner: 'black',
+      matchScore: [5, 5],
+      matchLength: 13,
+      crawford: false,
+      jacoby: false,
+      beavers: true
+    });
+
+    expect(request.dice).toEqual<[number, number]>([6, 6]);
+    expect(request.cubeValue).toBe(8);
+    expect(request.cubeOwner).toBe('black');
+    expect(request.matchScore).toEqual<[number, number]>([5, 5]);
+    expect(request.matchLength).toBe(13);
+    expect(request.crawford).toBe(false);
+    expect(request.jacoby).toBe(false);
+    expect(request.beavers).toBe(true);
+  });
+
+  it('falls back to the provided default dice when no roll is available', () => {
+    const game = createStubGame();
+    // Remove dice information from players
+    (game.activePlayer as any).dice = {
+      id: 'dice-white',
+      color: 'white',
+      stateKind: 'rolling'
+    };
+    (game.inactivePlayer as any).dice = {
+      id: 'dice-black',
+      color: 'black',
+      stateKind: 'inactive'
+    };
+    (game as any).activePlay = undefined;
+
+    const request = createHintRequestFromGame(game, { defaultDice: [5, 2] });
+
+    expect(request.dice).toEqual<[number, number]>([5, 2]);
+  });
+
+  it('can derive dice from the active play when player dice are unavailable', () => {
+    const game = createStubGame();
+    const doubledDice: BackgammonDiceRolled = {
+      id: 'double-dice',
+      color: 'white',
+      stateKind: 'rolled',
+      currentRoll: [4, 4],
+      total: 8
+    };
+
+    (game.activePlayer as any).dice = {
+      id: 'dice-white',
+      color: 'white',
+      stateKind: 'rolling'
+    };
+
+    (game as any).activePlay = {
+      id: 'play-double',
+      stateKind: 'doubled',
+      player: game.activePlayer,
+      board: game.board,
+      moves: [],
+      dice: doubledDice
+    };
+
+    expect(deriveDiceFromGame(game)).toEqual<[number, number]>([4, 4]);
+  });
+});
+
+function createStubGame(): BackgammonGame {
+  const board = createMinimalBoard();
+  const activePlayer = createMovingPlayer('white');
+  const inactivePlayer = createInactivePlayer('black');
+
+  const cube: BackgammonCube = {
+    id: 'cube-1',
+    stateKind: 'doubled',
+    owner: activePlayer,
+    value: 4,
+    offeredBy: undefined
+  } as BackgammonCube;
+
+  const matchInfo: MatchInfo = {
+    matchId: 'match-1',
+    gameNumber: 3,
+    matchLength: 7,
+    matchScore: { white: 2, black: 4 },
+    isCrawford: true
+  };
+
+  const game: BackgammonGame = {
+    id: 'game-1',
+    stateKind: 'moving',
+    players: [activePlayer, inactivePlayer],
+    board,
+    cube,
+    createdAt: new Date(),
+    activeColor: 'white',
+    activePlay: {
+      id: 'play-1',
+      stateKind: 'moving',
+      player: activePlayer,
+      board,
+      moves: []
+    } as any,
+    activePlayer,
+    inactivePlayer,
+    metadata: { matchInfo },
+    settings: {
+      allowUndo: false,
+      allowResign: true,
+      autoPlay: false,
+      showHints: false,
+      showProbabilities: false
+    },
+    rules: {
+      useCrawfordRule: true,
+      useJacobyRule: true,
+      useBeaverRule: false,
+      useRaccoonRule: false,
+      useMurphyRule: false,
+      useHollandRule: false
+    },
+    version: 'v1'
+  } as unknown as BackgammonGame;
+
+  return game;
+}
+
+function createMovingPlayer(color: 'white' | 'black'): BackgammonPlayer {
+  return {
+    id: `${color}-player`,
+    userId: `${color}-user`,
+    color,
+    direction: color === 'white' ? 'clockwise' : 'counterclockwise',
+    pipCount: 0,
+    isRobot: false,
+    rollForStartValue: 1,
+    stateKind: 'moving',
+    dice: {
+      id: `${color}-dice`,
+      color,
+      stateKind: 'rolled',
+      currentRoll: [3, 1],
+      total: 4
+    }
+  } as unknown as BackgammonPlayerMoving;
+}
+
+function createInactivePlayer(color: 'white' | 'black'): BackgammonPlayer {
+  return {
+    id: `${color}-player-inactive`,
+    userId: `${color}-user-inactive`,
+    color,
+    direction: color === 'white' ? 'clockwise' : 'counterclockwise',
+    pipCount: 0,
+    isRobot: false,
+    rollForStartValue: 1,
+    stateKind: 'inactive',
+    dice: {
+      id: `${color}-dice-inactive`,
+      color,
+      stateKind: 'inactive'
+    }
+  } as unknown as BackgammonPlayerInactive;
+}
+
+function createMinimalBoard(): BackgammonBoard {
+  return {
+    id: 'board-1',
+    points: Array.from({ length: 24 }, (_, index) => ({
+      id: `point-${index + 1}`,
+      kind: 'point',
+      position: {
+        clockwise: (index + 1) as any,
+        counterclockwise: (24 - index) as any
+      },
+      checkers: index === 0 ? [{ id: 'checker-1', color: 'white' }] : []
+    })),
+    bar: {
+      clockwise: { id: 'bar-white', kind: 'bar', direction: 'clockwise', position: { clockwise: 25, counterclockwise: 0 }, checkers: [] },
+      counterclockwise: { id: 'bar-black', kind: 'bar', direction: 'counterclockwise', position: { clockwise: 0, counterclockwise: 25 }, checkers: [] }
+    },
+    off: {
+      clockwise: { id: 'off-white', kind: 'off', direction: 'clockwise', position: { clockwise: 0, counterclockwise: 0 }, checkers: [] },
+      counterclockwise: { id: 'off-black', kind: 'off', direction: 'counterclockwise', position: { clockwise: 0, counterclockwise: 0 }, checkers: [] }
+    }
+  } as unknown as BackgammonBoard;
+}


### PR DESCRIPTION
## Summary
- add a TypeScript bridge that turns a BackgammonGame from @nodots-llc/backgammon-core into the HintRequest structure and expose matching utility getters
- extract the public TypeScript types into a shared module so the bridge and entrypoint share the same definitions while keeping the original API surface
- document the new workflow in the README and cover it with a focused Jest test to validate dice, cube, and match metadata handling

## Testing
- npm run build:ts
- npm test -- --runTestsByPath test/backgammon-core-bridge.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d885ed34348330aec64d51998ce0c5