### PR TITLE
Document running npm scripts from monorepo workspaces

### DIFF
--- a/gnubg-node-addon/README.md
+++ b/gnubg-node-addon/README.md
@@ -172,6 +172,17 @@ npm run build:ts
 npm test
 ```
 
+> **Working inside a larger workspace?**
+>
+> If this addon lives inside a monorepo (for example at `packages/gnubg-hints/gnubg-node-addon`), make sure you run the commands **from this directory** or pass `--prefix` so that npm targets only this package:
+>
+> ```bash
+> npm --prefix packages/gnubg-hints/gnubg-node-addon install
+> npm --prefix packages/gnubg-hints/gnubg-node-addon run build
+> ```
+>
+> Running `npm run build` from the workspace root will execute every package's build script.
+
 ## Performance
 
 Benchmarks comparing subprocess vs native addon:


### PR DESCRIPTION
## Summary
- document how to run npm install/build commands when the addon is vendored inside a larger workspace
- add explicit examples using npm --prefix so monorepo scripts only target this package

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d97773f9ac833080fa5dbea9811599