### PR TITLE
Ensure dist assets are published with the addon

### DIFF
--- a/gnubg-node-addon/.npmignore
+++ b/gnubg-node-addon/.npmignore
@@ -1,0 +1,56 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+
+# Build artifacts generated locally
+build/
+*.tgz
+
+# TypeScript artifacts
+*.tsbuildinfo
+
+# Coverage reports
+coverage/
+.nyc_output/
+
+# Environment files
+.env
+.env.local
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Editor directories and swap files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+logs/
+*.log
+
+# Temporary directories
+.tmp/
+tmp/
+
+# Development-only resources
+benchmark/
+examples/
+final_integration_test/
+final_integration_test.c
+scripts/
+test/
+test_core/
+test_core.c
+test_gnubg_link/
+test_gnubg_link.c
+run_hint.js
+show_actual_output.js
+test_hint_output.js
+test_simple_position_api.js
+test_specific_position.js
+test_position_4NvgATDgc_ABMA.js
+test_position_final.js
+test_position_id.js

--- a/gnubg-node-addon/include/gnubg-types.h
+++ b/gnubg-node-addon/include/gnubg-types.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2007-2009 Christian Anthon <anthon@kiku.dk>
+ * Copyright (C) 2007-2011 the AUTHORS
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * $Id: gnubg-types.h,v 1.9 2013/06/16 02:16:23 mdpetch Exp $
+ */
+
+#ifndef GNUBG_TYPES_H
+#define GNUBG_TYPES_H
+
+typedef unsigned int TanBoard[2][25];
+typedef const unsigned int (*ConstTanBoard)[25];
+
+typedef enum {
+    VARIATION_STANDARD,         /* standard backgammon */
+    VARIATION_NACKGAMMON,       /* standard backgammon with nackgammon starting
+                                 * position */
+    VARIATION_HYPERGAMMON_1,    /* 1-chequer hypergammon */
+    VARIATION_HYPERGAMMON_2,    /* 2-chequer hypergammon */
+    VARIATION_HYPERGAMMON_3,    /* 3-chequer hypergammon */
+    NUM_VARIATIONS
+} bgvariation;
+
+typedef enum {
+    GAME_NONE, GAME_PLAYING, GAME_OVER, GAME_RESIGNED, GAME_DROP
+} gamestate;
+
+typedef struct {
+    TanBoard anBoard;
+    unsigned int anDice[2];     /* (0,0) for unrolled dice */
+    int fTurn;                  /* who makes the next decision */
+    int fResigned;
+    int fResignationDeclined;
+    int fDoubled;
+    int cGames;
+    int fMove;                  /* player on roll */
+    int fCubeOwner;
+    int fCrawford;
+    int fPostCrawford;
+    int nMatchTo;
+    int anScore[2];
+    int nCube;
+    unsigned int cBeavers;
+    bgvariation bgv;
+    int fCubeUse;
+    int fJacoby;
+    gamestate gs;
+} matchstate;
+
+typedef union {
+    unsigned int data[7];
+} positionkey;
+
+typedef union {
+    unsigned char auch[10];
+} oldpositionkey;
+
+#endif


### PR DESCRIPTION
## Summary
- add an .npmignore to override the gitignore so the built dist/ outputs ship while excluding development-only folders
- include the GNU Backgammon gnubg-types.h header in the package so node-gyp can rebuild when installed from npm

## Testing
- npm run build
- npm pack
- npm install ../gnubg-hints/gnubg-node-addon/nodots-llc-gnubg-hints-1.0.0.tgz
- node -e "const mod = require('@nodots-llc/gnubg-hints'); console.log(typeof mod.GnuBgHints);"
- npx gnubg-hints-cli --help


------
https://chatgpt.com/codex/tasks/task_e_68d9835a5d5083308d8a5ce8ccf8df0d