### PR TITLE
Simplify addon npm scripts

### DIFF
--- a/gnubg-node-addon/package.json
+++ b/gnubg-node-addon/package.json
@@ -11,14 +11,14 @@
     "configure": "node-gyp configure",
     "build:native": "node-gyp build",
     "build:ts": "tsc",
-    "build": "npm run build:native && npm run build:ts",
-    "rebuild": "node-gyp rebuild && npm run build:ts",
+    "build": "node-gyp build && tsc",
+    "rebuild": "node-gyp rebuild && tsc",
     "test": "jest",
     "test:coverage": "jest --coverage --verbose",
     "install": "node-gyp rebuild",
     "publish:npm": "npm publish --access public",
-    "prepublishOnly": "npm run build",
-    "pretest": "npm run build:native"
+    "prepublishOnly": "node-gyp build && tsc",
+    "pretest": "node-gyp build"
   },
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
## Summary
- replace npm-run script chaining with direct node-gyp and TypeScript commands so package scripts execute locally

## Testing
- npm pack
- npm install ../gnubg-hints/gnubg-node-addon/nodots-llc-gnubg-hints-1.0.0.tgz

------
https://chatgpt.com/codex/tasks/task_e_68d98a30cc2883309f3f273b22b48f0b