### PR TITLE
feat: remove Node 20 version lock

### DIFF
--- a/gnubg-node-addon/binding.gyp
+++ b/gnubg-node-addon/binding.gyp
@@ -53,6 +53,7 @@
         "-lm"
       ],
       "defines": [
+        "NAPI_VERSION=8",
         "NAPI_DISABLE_CPP_EXCEPTIONS",
         "HAVE_CONFIG_H",
         "GNUBG_ADDON",

--- a/gnubg-node-addon/package.json
+++ b/gnubg-node-addon/package.json
@@ -8,7 +8,7 @@
     "gnubg-hints-cli": "dist/cli.js"
   },
   "scripts": {
-    "preinstall": "node -e \"if(parseInt(process.versions.node.split('.')[0],10)!==20){console.error('\\x1b[31mFATAL: Node.js 20.x required, found '+process.versions.node+'\\x1b[0m');process.exit(1)}\"",
+    "preinstall": "",
     "configure": "node ./bin/run-node-gyp.js configure",
     "build:native": "node ./bin/run-node-gyp.js build",
     "build:ts": "tsc",
@@ -23,7 +23,7 @@
     "pretest": "node ./bin/run-node-gyp.js build"
   },
   "engines": {
-    "node": ">=20 <21"
+    "node": ">=20"
   },
   "dependencies": {
     "@nodots-llc/backgammon-types": "file:../../types",


### PR DESCRIPTION
## Summary
- Remove `preinstall` script that hard-exits on non-Node-20
- Widen `engines` from `>=20 <21` to `>=20`
- Add `NAPI_VERSION=8` define to `binding.gyp` for ABI stability
- Verified: addon compiles and loads on Node 22.17.1

Fixes nodots/nodots-backgammon#288

## Test plan
- [ ] `node-gyp rebuild` succeeds on Node 20 and Node 22
- [ ] `node -e "require('./build/Release/gnubg_hints.node')"` loads on Node 22
- [ ] Full workspace build passes