### PR TITLE
fix(gnubg-hints): remove position ID swap + bump to 4.6.4-staging.15

### DIFF
--- a/gnubg-node-addon/package-lock.json
+++ b/gnubg-node-addon/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nodots-llc/gnubg-hints",
-  "version": "4.6.4-staging.0",
+  "version": "4.6.4-staging.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nodots-llc/gnubg-hints",
-      "version": "4.6.4-staging.0",
+      "version": "4.6.4-staging.15",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/gnubg-node-addon/package.json
+++ b/gnubg-node-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots-llc/gnubg-hints",
-  "version": "4.6.4-staging.14",
+  "version": "4.6.4-staging.15",
   "description": "GNU Backgammon hint engine for Node.js with TypeScript support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/gnubg-node-addon/src/index.ts
+++ b/gnubg-node-addon/src/index.ts
@@ -275,20 +275,9 @@ export class GnuBgHints {
     // Decode the position to get checker arrays
     const decoded = this.decodePositionId(positionId)
 
-    // If clockwise player is on roll, we need to swap the perspective
-    // Our canonical encoding: X = clockwise, O = counterclockwise
-    // GNU BG hint core expects player-on-roll in index 1 (O)
-    // So if clockwise is on roll, swap the arrays to move them to index 1
-    let effectivePositionId = positionId
-    if (activePlayerDirection === 'clockwise') {
-      // Swap X and O: clockwise player moves to O (index 1, on roll)
-      // getPositionId expects TanBoard format: [[...x], [...o]]
-      const swappedBoard = [decoded.o, decoded.x]
-      effectivePositionId = addon.getPositionId(swappedBoard)
-      logDebug('[gnubg-hints] getHintsFromPositionId: Swapped for clockwise player on roll')
-      logDebug('[gnubg-hints]   Original posId:', positionId)
-      logDebug('[gnubg-hints]   Swapped posId:', effectivePositionId)
-    }
+    // The position ID already has the on-roll player in TanBoard[0].
+    // No swap needed — exportToGnuPositionId handles the encoding.
+    const effectivePositionId = positionId
 
     return new Promise((resolve, reject) => {
       // Create minimal request object with just position ID and dice


### PR DESCRIPTION
## Summary
- Remove position ID swap in getHintsFromPositionId (CORE owns on-roll placement)
- Bump addon to 4.6.4-staging.15