### PR TITLE
fix(scripts): avoid set-e exit-1 in generate-databases

### DIFF
--- a/gnubg-node-addon/scripts/generate-databases.sh
+++ b/gnubg-node-addon/scripts/generate-databases.sh
@@ -124,19 +124,19 @@ SUCCESS=0
 WARNINGS=0
 
 if copy_or_generate_wd; then
-    ((SUCCESS++))
+    SUCCESS=$((SUCCESS + 1))
 else
-    ((WARNINGS++))
+    WARNINGS=$((WARNINGS + 1))
 fi
 
 if copy_or_generate_ts0; then
-    ((SUCCESS++))
+    SUCCESS=$((SUCCESS + 1))
 else
-    ((WARNINGS++))
+    WARNINGS=$((WARNINGS + 1))
 fi
 
 if copy_or_generate_os0; then
-    ((SUCCESS++))
+    SUCCESS=$((SUCCESS + 1))
 fi
 
 echo ""


### PR DESCRIPTION
Publish workflow blocker: ((SUCCESS++)) returns exit 1 when SUCCESS is 0, killing script under set -e.