### PR TITLE
fix(addon): tiebreak equity-tied bearoff hints; report DB load status

### DIFF
--- a/gnubg-node-addon/lib/gnubg_core.c
+++ b/gnubg-node-addon/lib/gnubg_core.c
@@ -7,9 +7,18 @@
 #include "glib-ext.h"
 #include "multithread.h"
 #include "output.h"
+#include "bearoff.h"
 #include <glib.h>
 #include <string.h>
 #include <stdlib.h>
+
+/* Bearoff DB pointers live in eval.c globals. Reach in to report load status
+ * so callers can detect the silent-failure mode where extended DBs are not
+ * shipped (gnubg_os.bd, gnubg_ts.bd) and eval falls through to the NN. */
+extern bearoffcontext *pbc1;
+extern bearoffcontext *pbc2;
+extern bearoffcontext *pbcOS;
+extern bearoffcontext *pbcTS;
 
 typedef int (*cfunc)(const void *, const void *);
 
@@ -74,6 +83,24 @@ int gnubg_initialize(const char *weights_path) {
     char *weights_binary = BuildFilename("gnubg.wd");
 
     EvalInitialise(weights, weights_binary, FALSE, NULL);
+
+    /* Surface bearoff DB load status so a degraded mode (missing extended
+     * DBs gnubg_os.bd / gnubg_ts.bd) is visible rather than silently falling
+     * back to the race neural net. See nodots/gnubg-hints#30. Suppress the
+     * line if NODOTS_LOG_LEVEL=silent or NODOTS_LOG_SILENT=1. */
+    {
+        const char *silent_env = g_getenv("NODOTS_LOG_SILENT");
+        const char *level_env = g_getenv("NODOTS_LOG_LEVEL");
+        int silent = (silent_env && silent_env[0] == '1') ||
+                     (level_env && g_ascii_strcasecmp(level_env, "silent") == 0);
+        if (!silent) {
+            g_printerr("[gnubg-hints] bearoff databases: pbc1=%s pbc2=%s pbcOS=%s pbcTS=%s\n",
+                       pbc1 ? "loaded" : "MISSING",
+                       pbc2 ? "loaded" : "MISSING",
+                       pbcOS ? "loaded" : "MISSING",
+                       pbcTS ? "loaded" : "MISSING");
+        }
+    }
 
     /* EvalInitialise sets neural net sizes needed by thread-local buffers. */
     MT_InitThreads();

--- a/gnubg-node-addon/src/index.ts
+++ b/gnubg-node-addon/src/index.ts
@@ -806,18 +806,66 @@ export class GnuBgHints {
     if (!normalization) {
       return []
     }
-    const baseEquity =
-      Array.isArray(gnubgHints) && gnubgHints.length > 0
-        ? (gnubgHints[0].equity ?? 0)
-        : 0
 
-    return (Array.isArray(gnubgHints) ? gnubgHints : []).map((hint, index) => ({
+    // Reorder equity-tied hints before downstream consumers see them.
+    // GNU's cubeful eval can rank lines that are mathematically tied
+    // (~1.0 cubeless equity, no gammon possible) in essentially-random
+    // order due to float-precision noise -- e.g. for issue-41's bear-off
+    // endgame the slow line ranked above the immediate-win line by
+    // ~5e-7 of equity. The racing principle "off > pips" breaks the tie
+    // deterministically. See nodots/gnubg-hints#30.
+    const orderedHints = this.applyEquityTiebreaker(
+      Array.isArray(gnubgHints) ? gnubgHints : []
+    )
+    const baseEquity = orderedHints.length > 0 ? (orderedHints[0].equity ?? 0) : 0
+
+    return orderedHints.map((hint, index) => ({
       moves: this.convertMovesFromGnuBg(hint?.moves, board, normalization),
       evaluation: this.normalizeEvaluation(hint?.evaluation),
       equity: hint?.equity ?? 0,
       rank: index + 1,
       difference: index === 0 ? 0 : (hint?.equity ?? 0) - baseEquity,
     }))
+  }
+
+  /**
+   * Reorder equity-tied hints so the line with more bear-offs comes first.
+   *
+   * GNU's eval already sorts by score, but cubeful equity computation adds
+   * NN-precision noise that can put a slow bear-off line ahead of a line
+   * that wins outright. This pass walks the (already-sorted) list, groups
+   * adjacent hints whose equity is within EQUITY_TIE_EPSILON, and
+   * reorders each group by descending bear-off count. Outside the epsilon
+   * the original GNU ordering is preserved exactly. The epsilon is set well
+   * below GNU's "doubtful" threshold (0.020) so meaningful equity
+   * differences are never overridden.
+   */
+  private static applyEquityTiebreaker(hints: any[]): any[] {
+    if (hints.length < 2) return hints
+    const EQUITY_TIE_EPSILON = 1e-4
+    const bearOffCount = (hint: any): number => {
+      const moves = this.normalizeGnuBgMoves(hint?.moves)
+      return moves.filter(([, to]) => to === -1).length
+    }
+    const result = hints.slice()
+    let i = 0
+    while (i < result.length) {
+      const groupEquity = result[i]?.equity ?? 0
+      let j = i + 1
+      while (
+        j < result.length &&
+        Math.abs((result[j]?.equity ?? 0) - groupEquity) <= EQUITY_TIE_EPSILON
+      ) {
+        j++
+      }
+      if (j - i > 1) {
+        const cluster = result.slice(i, j)
+        cluster.sort((a, b) => bearOffCount(b) - bearOffCount(a))
+        result.splice(i, cluster.length, ...cluster)
+      }
+      i = j
+    }
+    return result
   }
 
   /**

--- a/gnubg-node-addon/test/equity-tied-tiebreaker.test.ts
+++ b/gnubg-node-addon/test/equity-tied-tiebreaker.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression for issue nodots/gnubg-hints#30: equity-tied bearoff hints
+ * misranked by float-precision noise from cubeful eval.
+ *
+ * Production end-game (game bf09273a-... in nodots/backgammon-ai#41): black
+ * has 1 checker on point 2, 1 on point 1, 13 already off; white pip 18 (no
+ * gammon possible). With dice [1,4] the lines `2->1, 1->off` (slow, leaves a
+ * checker) and `1->off, 2->off` (immediate win) both have cubeless equity 1.0
+ * but cubeful eval ranks them in essentially-random order (5e-7 apart).
+ *
+ * Acceptance: hints[0] is the immediate-win line. The library tiebreaker
+ * applies the racing principle "off > pips" to equity-tied hints regardless
+ * of the cubeful wrapper's float noise.
+ */
+
+import { GnuBgHints } from '../src'
+
+describe('Equity-tied tiebreaker (issue #30)', () => {
+  beforeAll(async () => {
+    await GnuBgHints.initialize()
+    await GnuBgHints.configure({
+      evalPlies: 2,
+      moveFilter: 2,
+      usePruning: true,
+      noise: 0,
+    })
+  })
+
+  afterAll(() => {
+    GnuBgHints.shutdown()
+  })
+
+  // Position rwcAABQAAAAAAA: black on roll (counterclockwise), 2 checkers in
+  // home, white has 9 in home + 6 off. Captured directly from the production
+  // game referenced in issue #41.
+  const PRODUCTION_PID = 'rwcAABQAAAAAAA'
+
+  it.each([
+    [1, 4],
+    [4, 1],
+  ])(
+    'ranks the immediate-win bear-off line first for [%d,%d]',
+    async (d1, d2) => {
+      const hints = await GnuBgHints.getHintsFromPositionId(
+        PRODUCTION_PID,
+        [d1, d2],
+        5,
+        'counterclockwise',
+        'black'
+      )
+
+      expect(hints.length).toBeGreaterThanOrEqual(2)
+      const top = hints[0]
+      const second = hints[1]
+
+      // The two lines are within float-precision noise of equal equity.
+      expect(Math.abs((top.equity ?? 0) - (second.equity ?? 0))).toBeLessThan(
+        1e-3
+      )
+
+      // Top line must bear off both checkers (to=0 means off in raw GNU).
+      const bearOffMoves = (top.moves || []).filter(
+        (m: { moveKind?: string }) => m.moveKind === 'bear-off'
+      )
+      expect(bearOffMoves).toHaveLength(2)
+    }
+  )
+
+  it('preserves GNU ranking when equity differs beyond the tiebreak epsilon', async () => {
+    // For a roll where one line is clearly better, the tiebreaker must NOT
+    // override GNU. Use the standard opening 31 from the start position --
+    // 8/5 6/5 is meaningfully ahead of any alternative, far above 1e-4.
+    const STARTING_PID = '4HPwATDgc/ABMA' // standard opening
+    const hints = await GnuBgHints.getHintsFromPositionId(
+      STARTING_PID,
+      [3, 1],
+      5,
+      'clockwise',
+      'white'
+    )
+    expect(hints.length).toBeGreaterThanOrEqual(2)
+    // hints[0] should still be GNU's choice; equity gap should be > epsilon.
+    const gap = Math.abs((hints[0].equity ?? 0) - (hints[1].equity ?? 0))
+    expect(gap).toBeGreaterThan(1e-4)
+  })
+})


### PR DESCRIPTION
Closes #30. Production root cause for nodots/backgammon-ai#41.

## Background

For end-game bear-off positions, GNU's evaluator can return multiple lines with cubeless equity tied at exactly 1.0 (e.g. when both side's outcomes guarantee a win for the player on roll). The cubeful equity wrapper that runs after the bearoff DB lookup adds a tiny float-precision residual (~5e-7 = 2^-21) that varies between lines. `qsort(..., CompareMoves)` then ranks these float-noise differences as if they were real, putting whichever line happens to win the precision lottery first.

In the production game from `nodots/backgammon-ai#41` (position `rwcAABQAAAAAAA`, black on roll counterclockwise, dice `[1,4]`):

```
hints[0] equity=1.0000004768371582 seq=2->1 1->0   <- slow, leaves a checker
hints[1] equity=0.9999995231628418 seq=1->0 2->0   <- bears off both, immediate win
```

Both lines have cubeless equity 1.0 (no gammon possible — white has 6 borne off). The robot followed `hints[0]` and threw away the immediate win.

## Investigation

I added an init-time diagnostic that prints which bearoff DBs loaded, and a per-call diagnostic that prints `ClassifyPosition`'s result. Output:

```
[gnubg-hints] bearoff databases: pbc1=loaded pbc2=loaded pbcOS=MISSING pbcTS=MISSING
[gnubg-hints] hint position class=BEAROFF1 dice=[1,4]
```

So:

- `pbc1` (basic one-sided, `gnubg_os0.bd`) **loads** — the package ships it.
- `pbc2` (basic two-sided 6x6, `gnubg_ts0.bd`) **loads**.
- `pbcOS` and `pbcTS` (extended DBs, `gnubg_os.bd` / `gnubg_ts.bd`) are **NULL** because those files aren't in the package tree. `BearoffInit` fails silently (`bearoff.c:819`) when a file is absent.
- For this issue's position, `pbc2`'s 6-chequer-per-side limit excludes white (9 in home), so the classifier walks past `pbc2`/`pbcTS` and lands at `BEAROFF1`. **`pbc1` IS being consulted.** The float noise comes from the cubeful equity wrapping, not from missing DBs.

The original issue body (and my first comment on `backgammon-ai#41`) framed this as a "missing DB" problem. The diagnostic output corrected that — DB lookup is happening, the noise is downstream.

## Fix

`convertHintsFromGnuBg` now applies a deterministic tiebreaker before exposing the hint list to consumers (`src/index.ts`):

- Walk the already-sorted hint list.
- Group adjacent hints whose equity is within `EQUITY_TIE_EPSILON = 1e-4`.
- Reorder each group by descending bear-off count (the racing principle "off > pips").
- Outside the epsilon the original GNU ordering is preserved exactly.

The epsilon is 200× smaller than GNU's "doubtful" skill threshold (0.020), so no meaningful equity difference is ever overridden.

`gnubg_initialize` (`lib/gnubg_core.c`) also now logs which bearoff DBs loaded vs `MISSING` so the silent-failure mode for the extended DBs is surfaced. Suppressible via `NODOTS_LOG_SILENT=1` or `NODOTS_LOG_LEVEL=silent`.

## Verification

```
hints[0] 1->0 2->0   (immediate win)   <- now ranked first
hints[1] 2->1 1->0
```

End-to-end through `@nodots/backgammon-ai`'s robot turn execution: both `[1,4]` and `[4,1]` now produce `blackOff=15, blackOnPoints=0, state=completed` for the production position.

## Tests

- All 58 existing tests still pass.
- New `test/equity-tied-tiebreaker.test.ts` adds 3 cases:
  - `[1,4]` for `rwcAABQAAAAAAA` → top hint bears off both checkers
  - `[4,1]` for the same position → top hint bears off both checkers
  - Standard opening 3-1 → equity gap > 1e-4, GNU's ranking preserved (negative test)

## Test plan

- [x] `npx jest` (61/61 passing locally with the rebuilt addon)
- [x] AI-side end-to-end repro for the production position
- [ ] Verify CI passes
- [ ] Confirm downstream `@nodots/backgammon-ai` tests still pass once the addon is consumed via npm/local link