### PR TITLE
chore: release @nodots/gnubg-hints 1.0.3

### DIFF
--- a/gnubg-node-addon/package.json
+++ b/gnubg-node-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots/gnubg-hints",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "GNU Backgammon hint engine for Node.js with TypeScript support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bump to 1.0.3 for the workspace-wide release.

Bundles the bearoff tiebreaker fix from #31 (equity-tied bear-off lines now ranked by descending bear-off count).

## Why 1.0.3 (skipping 1.0.1/1.0.2)

@nodots/backgammon-types is already at 1.0.2 on npm. This release aligns every changed package and the workspace root at a common 1.0.3 to make the release coherent.

## Test plan

- [x] gnubg-hints PR #31 already merged + tested (61/61 jest passing)
- [ ] After merge: workspace-root release.yml publishes @nodots/gnubg-hints@1.0.3 to npm