### PR TITLE
chore: release 1.0.4

### DIFF
--- a/gnubg-node-addon/package.json
+++ b/gnubg-node-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots/gnubg-hints",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "GNU Backgammon hint engine for Node.js with TypeScript support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Single-commit version bump of `@nodots/gnubg-hints` from 1.0.3 → **1.0.4**, aligning the package with the workspace-wide 1.0.4 release.

## Note on history

Earlier in this branch's life I had a misread: my local `main` was stale and I thought the 1.0.3 release work was unmerged. In fact #32 already brought the equity-tied bear-off tiebreaker fix (#31) to `main` at version 1.0.3. This PR is therefore purely the 1.0.3 → 1.0.4 bump.

## Test plan

- [ ] CI passes on this branch
- [ ] Native addon still builds on linux/amd64 (verified via the api Docker build during deploy)