### PR TITLE
fix(addon): getTakeHint answered from the doubler's side

### DIFF
--- a/gnubg-node-addon/src/hint_wrapper.cpp
+++ b/gnubg-node-addon/src/hint_wrapper.cpp
@@ -537,7 +537,12 @@ TakeHint HintWrapper::getTakeHint(const HintRequest& request) {
     int gnubgResult = gnubg_hint_take(board, &ci, equities);
 
     if (gnubgResult >= 0) {
-        auto determineAction = [](int decision, double take, double drop) -> std::string {
+        // Every cubedecision that is not a PASS or BEAVER variant means the
+        // correct response to the double is take (e.g. NODOUBLE_TAKE: "the
+        // doubler shouldn't double, but if doubled, take"). The old default
+        // compared arDouble equities, which are from the DOUBLER's
+        // perspective, so it answered backwards.
+        auto determineAction = [](int decision) -> std::string {
             switch (decision) {
                 case DOUBLE_BEAVER:
                 case NODOUBLE_BEAVER:
@@ -551,14 +556,17 @@ TakeHint HintWrapper::getTakeHint(const HintRequest& request) {
                 case OPTIONAL_REDOUBLE_PASS:
                     return "drop";
                 default:
-                    return take > drop ? "take" : "drop";
+                    return "take";
             }
         };
 
-        result.action = determineAction(gnubgResult, equities[0], equities[1]);
-        result.takeEquity = equities[0];
-        result.dropEquity = equities[1];
-        result.eval.equity = equities[0];
+        result.action = determineAction(gnubgResult);
+        // arDouble's OUTPUT_TAKE/OUTPUT_DROP are equities for the player on
+        // roll in `ci` -- the potential doubler. TakeHint reports the TAKER's
+        // side, so negate (drop becomes -1 for the taker).
+        result.takeEquity = -equities[0];
+        result.dropEquity = -equities[1];
+        result.eval.equity = -equities[0];
     } else {
         result.action = "drop";
         result.takeEquity = -2.0;


### PR DESCRIPTION
Two defects in the take path, each sufficient to invert an answer:

1. The default action branch compared arDouble equities directly — but FindCubeDecision's arDouble is from the POTENTIAL DOUBLER's perspective, so `take > drop` picked exactly backwards. Every non-PASS/non-BEAVER cubedecision means the correct response to a double is take (e.g. NODOUBLE_TAKE: "don't double, but if doubled, take"), so the default is now simply "take".
2. takeEquity/dropEquity were returned unflipped. TakeHint reports the TAKER's side, so both are negated (drop becomes -1 for the taker, matching the protocol's documented scale).

Validated against cube theory on live positions: the start position reads take at +0.17 vs -1, and drop-vs-take positions bracket the +1 cash point exactly (double/take 1.039 → drop, 0.912 → take).

Merge FIRST: the adapter PR (nodots/gnubg-protocol-adapter) relies on these semantics for /v1/take.